### PR TITLE
replace zendesk links

### DIFF
--- a/repositories/quickstarts/_posts/2016-12-12-nodejs-quickstart.md
+++ b/repositories/quickstarts/_posts/2016-12-12-nodejs-quickstart.md
@@ -15,14 +15,14 @@ This guide will help you setup Runnable templates for a simple 2-tier Node.js ap
 ## Configuring the App
 
 1. Choose your GitHub org.
-2. On the _Configure_ page, click on the __Create Template__ button.  
-  ![node1]({{ site.baseurl }}/images/node1.png)  
-3. Find the repository you would like to configure the template for. In this case, we are starting with a simple Python repository.  
-  ![node2]({{ site.baseurl }}/images/node2.png)  
+2. On the _Configure_ page, click on the __Create Template__ button.
+  ![node1]({{ site.baseurl }}/images/node1.png)
+3. Find the repository you would like to configure the template for. In this case, we are starting with a simple Python repository.
+  ![node2]({{ site.baseurl }}/images/node2.png)
 4. Choose the first option to use our simple setup guide.
-5. Give your template a name. This name will be used to generate the template URLs of all the containers that will launch from this template. Check out [this](http://https://runnable.zendesk.com/hc/en-us/articles/212802006) article for more details on URLs in Runnable.
-6. Next, you’ll be able to select your app’s Stack Type, Version and Branch for your template. Go ahead and choose Node.js for your stack type, and select the version you want to use. Make sure you choose the branch that corresponds to your team’s main integration branch (‘master’  or ‘develop’ for example).  
-  ![node3]({{ site.baseurl }}/images/node3.png)  
+5. Give your template a name. This name will be used to generate the template URLs of all the containers that will launch from this template. Check out [this]({{site.baseurl}}/networking/runnable-urls-explained) article for more details on URLs in Runnable.
+6. Next, you’ll be able to select your app’s Stack Type, Version and Branch for your template. Go ahead and choose Node.js for your stack type, and select the version you want to use. Make sure you choose the branch that corresponds to your team’s main integration branch (‘master’  or ‘develop’ for example).
+  ![node3]({{ site.baseurl }}/images/node3.png)
 6. On the next step, you can specify additional Packages, Build Commands, and the Container CMD.
 
 ---
@@ -30,7 +30,7 @@ This guide will help you setup Runnable templates for a simple 2-tier Node.js ap
 ### Packages
 
 This option allows you to install any tools, libraries, or frameworks you need. Add multiple packages by separating them with spaces. You can specify packages that are listed in the Ubuntu Aptitude library.
-  ![node4]({{ site.baseurl }}/images/node4.png)  
+  ![node4]({{ site.baseurl }}/images/node4.png)
 
 ---
 
@@ -39,7 +39,7 @@ This option allows you to install any tools, libraries, or frameworks you need. 
 Use this option to specify any commands needed to build and prepare your app (supports UNIX bash format). These commands will run in the root folder of the repository after every push. This is also the perfect place to run any commands to build any assets (such as css, html and minified javascript code).
 
 For our simple API repository, this is where we’ll specify "npm install".
-  ![node5]({{ site.baseurl }}/images/node5.png)  
+  ![node5]({{ site.baseurl }}/images/node5.png)
 
 Note: Build commands cannot connect to any other container during a build. It is therefore not recommended to seed databases or communicate with another container using the Build Commands.
 
@@ -51,7 +51,7 @@ Here the main run command for your app is specified. Important: the container wi
 
 NOTE: Commands that run here will have network access to other Runnable containers. TIP: use "&&" to run multiple commands; for example, to run a migration on your database and start your app, you can specify "npm run migrations && npm start"
 
-  ![node6]({{ site.baseurl }}/images/node6.png)  
+  ![node6]({{ site.baseurl }}/images/node6.png)
 
 10. Click Next. Additional configuration options are revealed to customize your container further:
 
@@ -79,7 +79,7 @@ For more details, Check Out:
 Open up any ports your repository may need.
 
 Our simple API repository only needs port "3000" to be open.
-![node7]({{ site.baseurl }}/images/node7.png)  
+![node7]({{ site.baseurl }}/images/node7.png)
 
 1. Once you are happy with Save & Build to save our changes and trigger your first build.
 2. You will be automatically transitioned to the Logs tab of your configuration. Here you will be able to access:
@@ -90,7 +90,7 @@ Our simple API repository only needs port "3000" to be open.
 
 These logs correspond to all the output from the build process of your template. Any errors here will correspond to configuration options you have specified in your repository, Build Commands, Packages and Files & SSH keys.
 
-![node8]({{ site.baseurl }}/images/node8.png)  
+![node8]({{ site.baseurl }}/images/node8.png)
 
 ---
 
@@ -98,7 +98,7 @@ These logs correspond to all the output from the build process of your template.
 
 These logs correspond to all the output from the run process of a container launched from your template. Any errors here will correspond to configuration options you have specified in your CMD Command or Environment Variables.
 
-![node9]({{ site.baseurl }}/images/node9.png)  
+![node9]({{ site.baseurl }}/images/node9.png)
 
 > Your repository can crash for several reasons outside of your configuration on Runnable. There could be several factors ranging from a bug in your code or a misconfigured connection.
 
@@ -108,36 +108,36 @@ These logs correspond to all the output from the run process of a container laun
 
 This is a terminal session into a container launched from your template. This is useful to verify any configuration details you may want to confirm.
 
-![node10]({{ site.baseurl }}/images/node10.png)  
+![node10]({{ site.baseurl }}/images/node10.png)
 
 ---
 
 ### URL
 
-This is the Environment URL corresponding to the container launched from the default branch. Check [this](https://support.runnable.com/hc/en-us/articles/212802006-Runnable-URLs) article out for more about Runnable URLs.
+This is the Environment URL corresponding to the container launched from the default branch. [Read more]({{ site.baseurl }}/networking/runnable-urls-explained) about Runnable URLs.
 
-![node12]({{ site.baseurl }}/images/node12.png)  
+![node12]({{ site.baseurl }}/images/node12.png)
 
-* If everything went well, your build will complete successfully. Anytime you run across an error that you need help with, we have developers ready to help in real-time. Click on the chat bubble on the bottom left!  
+* If everything went well, your build will complete successfully. Anytime you run across an error that you need help with, we have developers ready to help in real-time. Click on the chat bubble on the bottom left!
 
 ---
 
 ## Connecting to a DB template
 
-1. Follow one of our DB Quickstarts to add and seed a database: [MySQL](https://support.runnable.com/hc/en-us/sections/202755686-Branches) / [PostgresQL](https://support.runnable.com/hc/en-us/sections/202755686-Branches) / [MongoDB](https://support.runnable.com/hc/en-us/sections/202755686-Branches).
+1. Follow one of our DB Quickstarts to add and seed a database: [MySQL]({{site.baseurl}}/services/databases/how-to-setup-your-mysql-database-template) / [PostgresQL]({{site.baseurl}}/services/databases/how-to-setup-your-postgres-database-template)
 
 2. In our case, we added a MySQL template.
-![node14]({{ site.baseurl }}/images/node14.png)  
+![node14]({{ site.baseurl }}/images/node14.png)
 
 3. Our repository is setup to use the environment variable "MYSQL_HOST" to reference the hostname for MYSQL. To connect our "api" repository template to the "MySQL" template, open up the "Environment Variables" tool in the "api" template configuration modal.
 
 > If you don't use Environment Variables for host discovery, you may have to modify your repository to use the Runnable template URL as your MySQL hostname. You can do this by either uploading a file using "Files & SSH Keys" or by actually modifying your repository on Github.com.
 
-4. Specify the the value for the "MYSQL_HOST" environment variable. From our article [Runnable URLs](https://support.runnable.com/hc/en-us/articles/212802006-Runnable-URLs), it is clear that we need to use MySQL's template URL to connect to it. As a convenience we provide all template URLs in the Environment Variables tab.
-![node15]({{ site.baseurl }}/images/node15.png) ![node16]({{ site.baseurl }}/images/node16.png) ![node17]({{ site.baseurl }}/images/node17.png)  
+4. Specify the the value for the "MYSQL_HOST" environment variable. From our article [Runnable URLs]({{site.baseurl}}/networking/runnable-urls-explained), it is clear that we need to use MySQL's template URL to connect to it. As a convenience we provide all template URLs in the Environment Variables tab.
+![node15]({{ site.baseurl }}/images/node15.png) ![node16]({{ site.baseurl }}/images/node16.png) ![node17]({{ site.baseurl }}/images/node17.png)
 
 5. Click Save & Build.
 
 6. The "api" template is now successfully connected with the "MySQL" template!
 
-Head on over to our [Branches](https://support.runnable.com/hc/en-us/sections/202755686-Branches) section to see how to containers from your templates.
+Head on over to our [Branches]({{site.baseurl}}/troubleshooting/i-dont-see-my-branches-being-added-on-runnable) section to see how to launch containers from your templates.

--- a/repositories/quickstarts/_posts/2016-12-12-python-quickstart.md
+++ b/repositories/quickstarts/_posts/2016-12-12-python-quickstart.md
@@ -66,8 +66,8 @@ Use this tool to add any addtional configuration files, other GitHub repositorie
 
 For more details, Check Out:
 
-1. [Adding Files to your Container](https://support.runnable.com/hc/en-us/articles/208221743)
-2. [Adding SSH Keys to build private modules](https://support.runnable.com/hc/en-us/articles/208018586-My-build-is-failing-because-of-No-Such-Key-or-Host-key-verification-failed-What-do-I-do-)
+1. [Adding Files to your Container]({{site.baseurl}}/repositories/adding-additional-files)
+2. [Adding SSH Keys to build private modules]({{site.baseurl}}/troubleshooting/my-build-is-failing-because-of-no-such-key-or-host-key-verification-failed-what-do-i-do}})
 
 ---
 
@@ -87,7 +87,7 @@ Since your app runs on port 8000, we'll click on the *Exposed Ports* tool and ex
 
 These logs correspond to all the output from the build process of your template. Any errors here will correspond to configuration options you have specified in your repository, Build Commands, Packages and Files & SSH keys.
 
-![Build Logs](https://support.runnable.com/hc/en-us/article_attachments/203094436/Screen_Shot_2016-03-10_at_3.06.10_PM.png)  
+![Build Logs](https://support.runnable.com/hc/en-us/article_attachments/203094436/Screen_Shot_2016-03-10_at_3.06.10_PM.png)
 
 ---
 
@@ -111,7 +111,7 @@ This is a terminal session into a container launched from your template. This is
 
 ### URL
 
-This is the Environment URL corresponding to the container launched from the default branch. Check [this](https://support.runnable.com/hc/en-us/articles/212802006-Runnable-URLs) article out for more about Runnable URLs.
+This is the Environment URL corresponding to the container launched from the default branch. Check [this]({{site.baseurl}}/networking/runnable-urls-explained) article out for more about Runnable URLs.
 
 ![Runnable URL]({{ site.baseurl }}/images/python-url.png)
 
@@ -119,13 +119,13 @@ This is the Environment URL corresponding to the container launched from the def
 
 * When you’re ready, click *Done* to see a summary of your new container.
 ![Done](https://support.runnable.com/hc/en-us/article_attachments/203162656/Screen_Shot_2016-03-16_at_9.43.16_PM.png)
-* If everything went well, your build will complete successfully. Anytime you run across an error that you need help with, we have developers ready to help in real-time. Click on the chat bubble on the bottom left!  
+* If everything went well, your build will complete successfully. Anytime you run across an error that you need help with, we have developers ready to help in real-time. Click on the chat bubble on the bottom left!
 
 ---
 
 ## Connecting to a DB template
 
-1. Follow one of our DB Quickstarts to add and seed a database: [MySQL](https://support.runnable.com/hc/en-us/sections/202755686-Branches) / [PostgresQL](https://support.runnable.com/hc/en-us/sections/202755686-Branches) / [MongoDB](https://support.runnable.com/hc/en-us/sections/202755686-Branches).
+1. Follow one of our DB Quickstarts to add and seed a database: [MySQL]({{site.baseurl}}/services/databases/how-to-setup-your-mysql-database-template) / [PostgresQL]({{site.baseurl}}/services/databases/how-to-setup-your-postgres-database-template)
 
 2. In our case, we added a MySQL template.
 ![MySQL 1]({{ site.baseurl }}/images/python-mysql1.png)
@@ -134,11 +134,11 @@ This is the Environment URL corresponding to the container launched from the def
 
 > If you don't use Environment Variables for host discovery, you may have to modify your repository to use the Runnable template URL as your MySQL hostname. You can do this by either uploading a file using "Files & SSH Keys" or by actually modifying your repository on Github.com.
 
-4. Specify the the value for the "MYSQL_HOST" environment variable. From our article [Runnable URLs](https://support.runnable.com/hc/en-us/articles/212802006-Runnable-URLs), it is clear that we need to use MySQL's template URL to connect to it. As a convenience we provide all template URLs in the Environment Variables tab.
+4. Specify the the value for the "MYSQL_HOST" environment variable. From our article [Runnable URLs]({{site.baseurl}}/networking/runnable-urls-explained), it is clear that we need to use MySQL's template URL to connect to it. As a convenience we provide all template URLs in the Environment Variables tab.
 ![MySQL 2]({{ site.baseurl }}/images/python-mysql2.png) ![MySQL 3]({{ site.baseurl }}/images/python-mysql3.png) ![MySQL 4]({{ site.baseurl }}/images/python-mysql4.png)
 
 5. Click *Save & Build*.
 
 6. The Pyhton template is now successfully connected with the "MySQL" template!
 
-Head on over to our [Branches](https://support.runnable.com/hc/en-us/sections/202755686-Branches) section to see how to containers from your templates.
+Head on over to our [Branches]({{site.baseurl}}/troubleshooting/i-dont-see-my-branches-being-added-on-runnable) section to see how to containers from your templates.

--- a/repositories/quickstarts/_posts/2016-12-12-ruby-on-rails-quickstart.md
+++ b/repositories/quickstarts/_posts/2016-12-12-ruby-on-rails-quickstart.md
@@ -78,8 +78,8 @@ Use this tool to add any addtional configuration files, other GitHub repositorie
 
 For more details, Check Out:
 
-1. [Adding Files to your Container](https://support.runnable.com/hc/en-us/articles/208221743)
-2. [Adding SSH Keys to build private modules](https://support.runnable.com/hc/en-us/articles/208018586-My-build-is-failing-because-of-No-Such-Key-or-Host-key-verification-failed-What-do-I-do-)
+1. [Adding Files to your Container]({{site.baseurl}}/repositories/adding-additional-files)
+2. [Adding SSH Keys to build private modules]({{site.baseurl}}/troubleshooting/my-build-is-failing-because-of-no-such-key-or-host-key-verification-failed-what-do-i-do)
 
 ---
 
@@ -120,7 +120,7 @@ This is a terminal session into a container launched from your template. This is
 
 ### URL
 
-This is the Environment URL corresponding to the container launched from the default branch. Check [this](https://support.runnable.com/hc/en-us/articles/212802006-Runnable-URLs) article out for more about Runnable URLs.
+This is the Environment URL corresponding to the container launched from the default branch. Check [this]({{site.baseurl}}/networking/runnable-urls-explained) article out for more about Runnable URLs.
 ![URL]({{ site.baseurl }}/images/create-rails-14.png)
 
 
@@ -134,7 +134,7 @@ This is the Environment URL corresponding to the container launched from the def
 
 ## Connecting to a DB template
 
-1. Follow one of our DB Quickstarts to add and seed a database: [MySQL](https://support.runnable.com/hc/en-us/sections/202755686-Branches) / [PostgresQL](https://support.runnable.com/hc/en-us/sections/202755686-Branches) / [MongoDB](https://support.runnable.com/hc/en-us/sections/202755686-Branches).
+1. Follow one of our DB Quickstarts to add and seed a database: [MySQL]({{site.baseurl}}/services/databases/how-to-setup-your-mysql-database-template) / [PostgresQL]({{site.baseurl}}/services/databases/how-to-setup-your-postgres-database-template)
 
 2. In our case, we added a PostgreSQL template.
 ![Postgres DB]({{ site.baseurl }}/images/rails-add-db-1.png)
@@ -144,7 +144,7 @@ This is the Environment URL corresponding to the container launched from the def
 
   > If you don't use Environment Variables for host discovery, you may have to modify your repository to use the Runnable template URL as your PostgreSQL hostname. You can do this by either uploading a file using "Files & SSH Keys" or by actually modifying your repository on Github.com.
 
-4. Specify the the value for the "DATABASE_URL" environment variable. From our article [Runnable URLs](https://support.runnable.com/hc/en-us/articles/212802006-Runnable-URLs), it is clear that we need to use PostgreSQL's template URL to connect to it. As a convenience we provide all template URLs in the Environment Variables tab.
+4. Specify the the value for the "DATABASE_URL" environment variable. From our article [Runnable URLs]({{site.baseurl}}/networking/runnable-urls-explained), it is clear that we need to use PostgreSQL's template URL to connect to it. As a convenience we provide all template URLs in the Environment Variables tab.
 ![Env Vars]({{ site.baseurl }}/images/rails-add-db-2.png) ![Insert URL]({{ site.baseurl }}/images/rails-add-db-3.png) ![Added URL]({{ site.baseurl }}/images/rails-add-db-4.png)
 
   > Make sure to add the PORT: 5432 as well!
@@ -153,4 +153,4 @@ This is the Environment URL corresponding to the container launched from the def
 
 6. The Rails template is now successfully connected with the "PostgreSQL" template!
 
-Head on over to our [Branches](https://support.runnable.com/hc/en-us/sections/202755686-Branches) section to see how to containers from your templates.
+Head on over to our [Branches]({{site.baseurl}}/troubleshooting/i-dont-see-my-branches-being-added-on-runnable) section to see how to containers from your templates.


### PR DESCRIPTION
Some of our urls link to documentation on our old support site. This PR updates all urls to our new support site (this repo).