### PR TITLE
fix quickstart icon alignment and @sm

### DIFF
--- a/_sass/articles/quickstart.scss
+++ b/_sass/articles/quickstart.scss
@@ -15,6 +15,7 @@
     height: 72px;
 
     @include media(sm) {
+      flex: 0 0 auto;
       margin-left: 0;
       margin-top: -$input-border;
     }
@@ -71,7 +72,6 @@
   }
 
   .icon {
-    height: 24px;
     margin: 0 $xs 0 0; // override article img
     width: 24px;
   }


### PR DESCRIPTION
Icon alignment issue:
<img width="776" alt="screen shot 2017-05-25 at 11 40 40 am" src="https://cloud.githubusercontent.com/assets/5341618/26465418/ed00b7a0-413f-11e7-8504-eceea2a67fed.png">

@sm issue:
<img width="425" alt="screen shot 2017-05-25 at 11 45 21 am" src="https://cloud.githubusercontent.com/assets/5341618/26465419/ed1ae850-413f-11e7-88d0-05a1a85e5d15.png">
