### PR TITLE
remove dev flag + consistent links

### DIFF
--- a/privacy/_posts/2017-06-08-adding-ssh-keys.md
+++ b/privacy/_posts/2017-06-08-adding-ssh-keys.md
@@ -3,7 +3,6 @@ title: Adding SSH Keys
 short: Adding SSH Keys
 category: privacy
 order: 3
-development: true
 ---
 
 An SSH key will allow services in your project to access any private repositories they depend on when building.

--- a/repositories/quickstarts/_posts/2017-05-07-quickstart-guides.md
+++ b/repositories/quickstarts/_posts/2017-05-07-quickstart-guides.md
@@ -9,7 +9,7 @@ A Dockerfile is a file that contains instructions for building an image that can
 
 If your app doesn't use Dockerfiles, don't worry! this guide will show you how to generate them from your source code and settings you configure. Then we'll point you to the next steps for setting up your application.
 
-> **Note:** Creating Dockerfiles is a great way to start using Runnable, but some features are reserved for apps that use Docker Compose:
+> **Note:** Creating Dockerfiles is a great way to start using Runnable, but some features are reserved for apps that [use Docker Compose]({{ site.baseurl }}/docker-compose/launching-your-first-environment):
 >
 > - Automatically creating isolated stacks for branches
 > - Running automated tests


### PR DESCRIPTION
- Removes the dev flag from the SSH Key article.
- Adds a link on the "use Docker Compose" copy for consistency.